### PR TITLE
Fix UID purge bugs with table prefix and MySQL syntax

### DIFF
--- a/AuxProtect_Core/src/main/java/dev/heliosares/auxprotect/database/SQLManager.java
+++ b/AuxProtect_Core/src/main/java/dev/heliosares/auxprotect/database/SQLManager.java
@@ -320,7 +320,7 @@ public class SQLManager extends ConnectionManager {
             }
 
             // Step 3: Delete the UIDs
-            int count_ = executeReturnRows(connection, "DELETE FROM auxprotect_uids WHERE uid IN (SELECT auxprotect_uids.uid FROM auxprotect_uids LEFT JOIN temp_uids AS temp ON auxprotect_uids.uid = temp.uid WHERE temp.uid IS NULL)");
+            int count_ = executeReturnRows(connection, "DELETE FROM " + Table.AUXPROTECT_UIDS + " WHERE uid IN (SELECT uid FROM (SELECT uids.uid FROM " + Table.AUXPROTECT_UIDS + " AS uids LEFT JOIN temp_uids AS temp ON uids.uid = temp.uid WHERE temp.uid IS NULL) AS to_delete)");
 
             // Step 4: Drop the Temporary Table
             execute(connection, "DROP " + (isMySQL() ? "TEMPORARY " : "") + "TABLE IF EXISTS temp_uids");


### PR DESCRIPTION
Fixes #32

## Summary

This PR fixes two critical bugs in the `purgeUIDs()` method that prevented it from working correctly in MySQL environments with table prefixes configured.

## Issues Fixed

### 1. Table Prefix Not Applied
The DELETE query hardcoded `auxprotect_uids` instead of using the configured table prefix, causing "Table doesn't exist" errors when users configured a custom prefix.

**Before:**
```java
"DELETE FROM auxprotect_uids WHERE ..."
```

**After:**
```java
"DELETE FROM " + Table.AUXPROTECT_UIDS + " WHERE ..."
```

### 2. MySQL Syntax Error
The original query violated MySQL's restriction against referencing the target table in its own FROM clause, resulting in: "You can't specify target table 'auxprotect_uids' for update in FROM clause"

**Before:**
```sql
DELETE FROM auxprotect_uids 
WHERE uid IN (
  SELECT auxprotect_uids.uid 
  FROM auxprotect_uids 
  LEFT JOIN temp_uids AS temp ON auxprotect_uids.uid = temp.uid 
  WHERE temp.uid IS NULL
)
```

**After:**
```sql
DELETE FROM [table] 
WHERE uid IN (
  SELECT uid FROM (
    SELECT uids.uid 
    FROM [table] AS uids 
    LEFT JOIN temp_uids AS temp ON uids.uid = temp.uid 
    WHERE temp.uid IS NULL
  ) AS to_delete
)
```

The fix wraps the subquery in a derived table, which MySQL materializes first, allowing it to be safely used in the DELETE statement.

## Testing Notes

The `refactor-modules` branch currently has pre-existing compilation errors unrelated to this change (missing `BusyException` declarations and a static method reference issue). This PR only modifies the `purgeUIDs()` method in `SQLManager.java` and does not introduce any new compilation issues.

The fix is compatible with both MySQL and SQLite databases.